### PR TITLE
Fix 'Battle for Wesnoth' link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Hexwar
 
 Hexwar is a simple turn based, hexagon map, strategy game in the tradition of [Panzer
 General](http://en.wikipedia.org/wiki/Panzer_General), [*Uniwar*](http://uniwar.com),
-and [Battle for Wesnoth](www.wesnoth.org).
+and [Battle for Wesnoth](http://www.wesnoth.org/).
 
 It's backend is in Ruby on Rails, but most of game is written in pure javascript 
 with jQuery. The graphics are taken from the excellent opensourced game 


### PR DESCRIPTION
It would link to 'https://github.com/mgfreshour/hexwar/blob/master/www.wesnoth.org' before.